### PR TITLE
Make packer and unpacker linux-friendly

### DIFF
--- a/repack_smallf.cpp
+++ b/repack_smallf.cpp
@@ -24,7 +24,7 @@ std::map<std::string, size_t> getFiles(std::string folderName){
 			filePath = filePath.substr(folderName.length()+1, std::string::npos);
 
 			std::cout << "Located file " << filePath << " of size " << fileSize << " bytes" << std::endl;
-			std::replace(filePath.begin(), filePath.end(), '/', '\\');
+                        std::replace(filePath.begin(), filePath.end(), '\\', '/');
 			files.insert({filePath, fileSize});
 		}
 	}

--- a/unpack_smallf.cpp
+++ b/unpack_smallf.cpp
@@ -64,7 +64,7 @@ std::map<int, std::string> buildFileList(FILE* file, const char* smallfName){
 			fileName += (char)getc(file);
 		}
 		std::cout << "Located file " << fileName << " at offset " << offset << std::endl;
-		fileList.insert({offset, folderName + "\\" + fileName});
+                fileList.insert({offset, folderName + "/" + fileName});
 
 		getc(file); // Advance to next file
 	}


### PR DESCRIPTION
## Summary
- update path separator handling in `repack_smallf.cpp`
- use forward slashes in `unpack_smallf.cpp`

## Testing
- `g++ -std=c++17 repack_smallf.cpp -o repack_smallf`
- `g++ -std=c++17 unpack_smallf.cpp -o unpack_smallf`
- `./unpack_smallf smallf.dat`
- `./repack_smallf smallf`

------
https://chatgpt.com/codex/tasks/task_e_6883c28377b48321b61f07d484af4f8e