### PR TITLE
Implement frame-aware YUK tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Full Auto 2 YUK Tools
+
+This repository contains simple utilities for working with the `*.yuk` music container used in **Full Auto 2: Battlelines**.
+
+- `extract_yuk.cpp` – extracts the interleaved ATRAC streams from a YUK file.
+- `compress_yuk.cpp` – rebuilds a YUK file from the extracted streams.
+- `validate_yuk.cpp` – checks extracted streams for valid headers and frame alignment.
+
+## Building
+
+All programs are single source files that can be built with a C++17 compiler:
+
+```bash
+g++ -std=c++17 -o extract_yuk extract_yuk.cpp
+g++ -std=c++17 -o compress_yuk compress_yuk.cpp
+g++ -std=c++17 -o validate_yuk validate_yuk.cpp
+```
+
+`at3tool/ps3_at3tool.exe` and `vgmstream` must be present if you plan to convert audio automatically. See the notes below.
+
+## Usage
+
+### Extract
+
+```
+./extract_yuk <input.yuk> <output_dir>
+```
+
+The extractor creates two folders under `<output_dir>`:
+
+- `atrac/` – contains the raw ATRAC streams (`*_StreamX.atrac`) and
+  corresponding headers (`*_StreamX.hdr`).
+- `wav/` – if `vgmstream-cli.exe` is present in the `vgmstream/` subfolder,
+  WAV conversions of the streams will be written here.
+
+A small `atrac.txth` file describing the streams is also generated for use with
+`vgmstream`.
+
+### Compress
+
+```
+./compress_yuk <input_dir> <output.yuk>
+```
+
+`<input_dir>` must contain eight WAV files named
+`<input_dir>_Stream0.wav` through `Stream7.wav` along with matching header files
+`*.hdr` produced by the extractor. The compressor converts the WAVs back to ATRAC
+using `ps3_at3tool.exe`, reinserts the saved headers and interleaves the streams
+while ensuring frame alignment.
+
+### Validate
+
+```
+./validate_yuk <stream_prefix>
+```
+
+`<stream_prefix>` should be the path and base name of extracted ATRAC files
+(e.g. `out/atrac/music_Stream`). The validator checks each stream for a valid
+RIFF header and that its length is a multiple of the 0x180 ATRAC frame size.
+
+## Notes
+
+- `ps3_at3tool.exe` must be placed under `at3tool/` for compression.
+- `vgmstream-cli.exe` can be placed under `vgmstream/` to enable automatic
+  WAV conversion when extracting.

--- a/validate_yuk.cpp
+++ b/validate_yuk.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+bool validateFile(const std::string& path){
+    FILE* f = fopen(path.c_str(), "rb");
+    if(!f){
+        std::cout << "File " << path << " not found" << std::endl;
+        return false;
+    }
+    char hdr[4];
+    if(fread(hdr,1,4,f) != 4){
+        std::cout << path << ": cannot read header" << std::endl;
+        fclose(f);
+        return false;
+    }
+    bool headerOk = hdr[0]=='R' && hdr[1]=='I' && hdr[2]=='F' && hdr[3]=='F';
+    fseek(f,0,SEEK_END);
+    long size = ftell(f);
+    long dataSize = size > 464 ? size - 464 : 0;
+    bool frameAligned = (dataSize % 0x180) == 0;
+    fclose(f);
+
+    if(!headerOk)
+        std::cout << path << ": invalid ATRAC header" << std::endl;
+    if(!frameAligned)
+        std::cout << path << ": data size not frame aligned" << std::endl;
+    return headerOk && frameAligned;
+}
+
+int main(int argc,char* argv[]){
+    if(argc!=2){
+        std::cout << "Usage: " << argv[0] << " [stream prefix]" << std::endl;
+        return 1;
+    }
+    std::string prefix = argv[1];
+    bool ok = true;
+    for(int i=0;i<8;i++){
+        std::string file = prefix + "_Stream" + std::to_string(i) + ".atrac";
+        if(!validateFile(file))
+            ok = false;
+    }
+    if(ok)
+        std::cout << "All streams validated successfully." << std::endl;
+    return ok?0:1;
+}
+


### PR DESCRIPTION
## Summary
- handle ATRAC3 headers and frame alignment when extracting and compressing
- record headers in `.hdr` files when extracting
- keep headers when rebuilding YUK files
- add optional size debugging output
- include a small validator utility
- document how to build and use the tools

## Testing
- `g++ -std=c++17 -o extract_yuk extract_yuk.cpp`
- `g++ -std=c++17 -o compress_yuk compress_yuk.cpp`
- `g++ -std=c++17 -o validate_yuk validate_yuk.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6888c7e68a0083218659d22051283096