### PR TITLE
Add raw validation mode and fix extraction alignment

### DIFF
--- a/extract_yuk.cpp
+++ b/extract_yuk.cpp
@@ -70,11 +70,10 @@ std::vector<std::string> extractStreams(FILE* file, std::string outputPath){
         for(int j = 0; j < 8; j++){
             fread(buffer, sizeof(char), 0x6000, file);
             if(i == 0){
+                // Save the encoder header separately but also keep it in the output
                 fwrite(buffer, sizeof(char), 464, headerStreams[j]);
-                fwrite(buffer + 464, sizeof(char), 0x6000 - 464, outputStreams[j]);
-            }else{
-                fwrite(buffer, sizeof(char), 0x6000, outputStreams[j]);
             }
+            fwrite(buffer, sizeof(char), 0x6000, outputStreams[j]);
         }
     }
 
@@ -91,7 +90,7 @@ std::vector<std::string> extractStreams(FILE* file, std::string outputPath){
         fclose(headerStreams[i]);
     }
 
-    size_t perStreamSize = 464 + numChunks * 0x6000 + extraFrames * frameSize;
+    size_t perStreamSize = numChunks * 0x6000 + extraFrames * frameSize;
     std::cout << "File size: " << fileSize << " bytes" << std::endl;
     std::cout << "Per-stream size: " << perStreamSize << " bytes" << std::endl;
 

--- a/validate_yuk.cpp
+++ b/validate_yuk.cpp
@@ -3,22 +3,31 @@
 #include <string>
 #include <vector>
 
-bool validateFile(const std::string& path){
+bool validateFile(const std::string& path, bool rawMode){
     FILE* f = fopen(path.c_str(), "rb");
     if(!f){
         std::cout << "File " << path << " not found" << std::endl;
         return false;
     }
+
     char hdr[4];
-    if(fread(hdr,1,4,f) != 4){
-        std::cout << path << ": cannot read header" << std::endl;
-        fclose(f);
-        return false;
+    bool headerOk = true;
+    if(!rawMode){
+        if(fread(hdr,1,4,f) != 4){
+            std::cout << path << ": cannot read header" << std::endl;
+            fclose(f);
+            return false;
+        }
+        headerOk = hdr[0]=='R' && hdr[1]=='I' && hdr[2]=='F' && hdr[3]=='F';
+    }else{
+        // In raw mode the ATRAC header is stored separately and may not contain
+        // a standard RIFF wrapper. Skip header validation.
+        headerOk = true;
     }
-    bool headerOk = hdr[0]=='R' && hdr[1]=='I' && hdr[2]=='F' && hdr[3]=='F';
+
     fseek(f,0,SEEK_END);
     long size = ftell(f);
-    long dataSize = size > 464 ? size - 464 : 0;
+    long dataSize = rawMode ? size : (size > 464 ? size - 464 : 0);
     bool frameAligned = (dataSize % 0x180) == 0;
     fclose(f);
 
@@ -30,15 +39,25 @@ bool validateFile(const std::string& path){
 }
 
 int main(int argc,char* argv[]){
-    if(argc!=2){
-        std::cout << "Usage: " << argv[0] << " [stream prefix]" << std::endl;
+    bool rawMode = false;
+    if(argc < 2 || argc > 3){
+        std::cout << "Usage: " << argv[0] << " [stream prefix] [--raw]" << std::endl;
         return 1;
+    }
+    if(argc == 3){
+        std::string flag = argv[2];
+        if(flag == "--raw")
+            rawMode = true;
+        else{
+            std::cout << "Unknown option: " << flag << std::endl;
+            return 1;
+        }
     }
     std::string prefix = argv[1];
     bool ok = true;
     for(int i=0;i<8;i++){
         std::string file = prefix + "_Stream" + std::to_string(i) + ".atrac";
-        if(!validateFile(file))
+        if(!validateFile(file, rawMode))
             ok = false;
     }
     if(ok)


### PR DESCRIPTION
## Summary
- support `--raw` option in `validate_yuk` to skip RIFF header check
- keep ATRAC header bytes in extracted streams to preserve frame alignment

## Testing
- `g++ -std=c++17 -o validate_yuk validate_yuk.cpp`
- `g++ -std=c++17 -o extract_yuk extract_yuk.cpp`
- `./extract_yuk asphault_masaugrace.yuk sample_output_fixed`
- `./validate_yuk sample_output_fixed/atrac/asphault_masaugrace --raw`

------
https://chatgpt.com/codex/tasks/task_e_6888cd65901c8321b409ee43a22bf6cc